### PR TITLE
使用中间件记录接口处理所需时间

### DIFF
--- a/TigoWeb/URLpattern.go
+++ b/TigoWeb/URLpattern.go
@@ -81,7 +81,7 @@ func (urlPattern *UrlPattern) AppendUrlPattern(uri string, v interface {
 func (urlPattern *UrlPattern) AppendRouterPattern(router Router, v interface {
 	Handle(http.ResponseWriter, *http.Request)
 }) {
-	baseMiddleware := []Middleware{InternalServerErrorMiddleware}
+	baseMiddleware := []Middleware{RequestProcessTimeMiddleware, InternalServerErrorMiddleware}
 	baseMiddleware = append(baseMiddleware, router.Middleware...)
 	middleware := chainMiddleware(baseMiddleware...)
 	http.HandleFunc(router.Url, middleware(v.Handle))

--- a/TigoWeb/middleware.go
+++ b/TigoWeb/middleware.go
@@ -42,3 +42,13 @@ func InternalServerErrorMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		next.ServeHTTP(w, r)
 	})
 }
+
+// RequestProcessTimeMiddleware 用来记录接口处理请求所用时间的中间件
+func RequestProcessTimeMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestStart := time.Now().Nanosecond() / 1e6
+		next.ServeHTTP(w, r)
+		requestEnd := time.Now().Nanosecond() / 1e6
+		logger.Trace.Printf("%s %s %dms", r.Method, r.RequestURI, requestEnd-requestStart)
+	})
+}

--- a/TigoWeb/middleware.go
+++ b/TigoWeb/middleware.go
@@ -2,7 +2,9 @@ package TigoWeb
 
 import (
 	"errors"
+	"github.com/karldoenitz/Tigo/logger"
 	"net/http"
+	"time"
 )
 
 // Middleware http中间件


### PR DESCRIPTION
将记录接口响应时间的功能写成一个中间件。

