### PR TITLE
增加一个获取router的函数

### DIFF
--- a/TigoWeb/application.go
+++ b/TigoWeb/application.go
@@ -20,6 +20,10 @@ type Application struct {
 	muxRouter   *mux.Router // gorilla的路由
 }
 
+func (application *Application) GetRouter() (router *mux.Router) {
+	return application.muxRouter
+}
+
 // http服务启动函数
 func (application *Application) run() {
 	address := fmt.Sprintf("%s:%d", application.IPAddress, application.Port)


### PR DESCRIPTION
增加一个GetRouter函数，用户从application中获取已经初始化的router，用于在静态文件服务中挂载中间件